### PR TITLE
Add assertions for task number during marking and unmarking tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,5 +55,6 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }
 

--- a/src/main/java/tira/task/TaskList.java
+++ b/src/main/java/tira/task/TaskList.java
@@ -8,7 +8,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.io.PrintWriter;
-import java.io.IOException;
 
 
 public class TaskList {
@@ -30,6 +29,7 @@ public class TaskList {
     }
 
     public void markTask(String command, String[] splitCommand) throws TiraException {
+        assert Integer.valueOf(splitCommand[1]) > 0 : "Task number should be more than 0";
         if (splitCommand.length < 2 && command.equals("mark")){
             throw new TiraException("MRAW?? WHERE IS THE TASK?");
         }
@@ -41,6 +41,7 @@ public class TaskList {
     }
 
     public void unmarkTask(String command, String[] splitCommand) throws TiraException {
+        assert Integer.valueOf(splitCommand[1]) > 0 : "Task number should be more than 0";
         if (splitCommand.length < 2 && command.equals("unmark")) {
             throw new TiraException("MRAW?? WHERE IS THE TASK?");
         }
@@ -101,6 +102,7 @@ public class TaskList {
     }
 
     public void delete(String[] splitCommand) throws TiraException{
+        assert Integer.valueOf(splitCommand[1]) > 0 : "Task number should be more than 0";
         if (splitCommand.length < 2) {
             throw new TiraException("MRAW?? WHERE IS THE TASK?");
         }

--- a/src/test/java/tira/Task/TaskListTest.java
+++ b/src/test/java/tira/Task/TaskListTest.java
@@ -32,7 +32,7 @@ public class TaskListTest{
     public void testMarkTask() throws TiraException {
         TaskList tasks = new TaskList();
         tasks.addToDo("todo Finish assignment", "todo Finish assignment".split(" "));
-        tasks.markTask("mark 1", "mark 1".split(" "));
+        tasks.markTask("mark -1", "mark -1".split(" "));
         assertTrue(tasks.getTasks().get(0).getIsDone());
     }
 


### PR DESCRIPTION
Marking and unmarking tasks don't check for positive task number. This could lead to indexing error while accessing the tasks from the ArrayList of tasks.

Let's use assertion to ensure that the task number being marked and unmarked is positive and non-zero in the taskList class.

Also refactored several import lines.